### PR TITLE
add TinyWireM support for ATtiny85

### DIFF
--- a/FRAM.h
+++ b/FRAM.h
@@ -9,7 +9,14 @@
 
 
 #include "Arduino.h"
-#include "Wire.h"
+#if defined(__AVR_ATtiny85__) && !defined(TwoWire_h)
+  #include "TinyWireM.h"
+  #define Wire TinyWireM
+  #define TwoWire USI_TWI
+  #pragma message(" [𝗪𝗔𝗥𝗡𝗜𝗡𝗚] Defaulting to 'TinyWireM.h'. 'Wire' is defined as 'TinyWireM', and 'TwoWire' as 'USI_TWI'. To override or fall back, include 'Wire.h' above the library.")
+#else
+  #include "Wire.h"
+#endif
 
 
 #define FRAM_LIB_VERSION              (F("0.8.1"))


### PR DESCRIPTION
## Intro
This is a simple commit that introduces [TinyWireM](https://github.com/adafruit/TinyWireM) support for [ATtiny85](https://www.microchip.com/en-us/product/attiny85); a lightweight I2C library optimized for ATtiny microcontrollers. The implementation although it default to `TinyWireM.h`, it allows for fallback to `Wire.h` by just including `Wire.h` above `FRAM.h`.

## Thought process
Since it *(the library)* may have been used with `Wire.h` and ATtiny85 in the past, I decided to not make any intrusive\breaking changes and just simply add a few macro-definitions, a macro-condition and a warning-message. But then I thought that someone may after all, still want to keep `Wire.h`, so I added `... && !defined(TwoWire_h)`  too.

## Outro
I did a simple test using FM24V10-GTR + ATtiny85 both with `Wire.h` and `TinyWireM.h` and so far seems to work fine. Since I'm working on a more complex project, if any issue appeears, will probably come out, but as of now it seems OK.